### PR TITLE
Populate views with default columns

### DIFF
--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -549,11 +549,29 @@ listView("cnaas") {
     jobs {
         regex(/.*cnaas.*/)
     }
+    columns {
+        status()
+        weather()
+        name()
+        lastSuccess()
+        lastFailure()
+        lastDuration()
+        buildButton()
+    }
 }
 
 listView("comanage") {
     jobs {
         regex(/^comanage.*/)
+    }
+    columns {
+        status()
+        weather()
+        name()
+        lastSuccess()
+        lastFailure()
+        lastDuration()
+        buildButton()
     }
 }
 
@@ -564,6 +582,15 @@ listView("eduid") {
         name("VCCS")
         regex(/.*eduid.*/)
     }
+    columns {
+        status()
+        weather()
+        name()
+        lastSuccess()
+        lastFailure()
+        lastDuration()
+        buildButton()
+    }
 }
 
 listView("jenkins") {
@@ -571,10 +598,28 @@ listView("jenkins") {
         name("bootstrap-docker-builds")
         regex(/.*jenkins.*/)
     }
+    columns {
+        status()
+        weather()
+        name()
+        lastSuccess()
+        lastFailure()
+        lastDuration()
+        buildButton()
+    }
 }
 
 listView("se-leg") {
     jobs {
         regex(/.*se-leg.*/)
+    }
+    columns {
+        status()
+        weather()
+        name()
+        lastSuccess()
+        lastFailure()
+        lastDuration()
+        buildButton()
     }
 }


### PR DESCRIPTION
Somehow I managed to miss that when views are created via job-dsl, the
they don't get the default columns, so this adds the default columns to
our views.