### PR TITLE
Migrate docker jobs to docker-plugin

### DIFF
--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -484,6 +484,8 @@ if (binding.hasVariable("DEV_MODE") && "${DEV_MODE}" != "" && DEV_MODE.toBoolean
     is_dev_mode = true
 }
 
+def failure_in_repos = false
+
 for (org in orgs) {
     //TODO: Should we set a per_page=100 (100 is max) to decrese the number of api calls,
     // So we don't get ratelimited as easy?
@@ -548,6 +550,7 @@ for (org in orgs) {
                     out.println(ex.toString());
                     out.println(ex.getMessage());
                     out.println("---- Trying next repo ----")
+                    failure_in_repos = true
                 }
             }
         }
@@ -649,3 +652,6 @@ listView("se-leg") {
         buildButton()
     }
 }
+
+if (failure_in_repos)
+    SEED_JOB.getLastBuild().setResult(hudson.model.Result.UNSTABLE)

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -7,10 +7,9 @@ import java.io.FileNotFoundException
 import java.io.IOException
 
 // Used for merging .jenkins.yaml in to default env
-Map.metaClass.addNested = { Map rhs ->
-    def lhs = delegate
-    rhs.each { k, v -> lhs[k] = lhs[k] in Map ? lhs[k].addNested(v) : v }
-    lhs
+def addNested(lhs, rhs) {
+    rhs.each { k, v -> lhs[k] = lhs[k] in Map ? addNested(lhs[k], v) : v }
+    return lhs
 }
 
 // https://stackoverflow.com/questions/7087185/retry-after-exception-in-groovy
@@ -113,7 +112,7 @@ def load_env(repo) {
         if (yaml_text != fixed_yaml_text)
             out.println("FIXME: This repo contains non compliant yaml")
         def repo_env = new Yaml().load(fixed_yaml_text)
-        env.addNested(repo_env)
+        env = addNested(env, repo_env)
     } catch (FileNotFoundException ex) {
         out.println("No .jenkins.yaml for ${env.full_name}... will use defaults")
     }

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -188,14 +188,12 @@ def add_job(env, is_dev_mode) {
     if (env.builders.size() > 0 && !_is_disabled(env)) {
         out.println("generating job for ${env.full_name} using builders: ${env.builders}")
 
-        def build_in_docker = _build_in_docker(env)
-        def cloud = true
 
         job(env.name) {
             properties {
                 githubProjectUrl("https://github.com/${env.repo_full_name}")
                 // Build in docker
-                if (cloud && build_in_docker) {
+                if (_build_in_docker(env)) {
                     dockerJobTemplateProperty {
                         cloudname("")  // Empty means pick one.
                         template {
@@ -364,24 +362,6 @@ def add_job(env, is_dev_mode) {
                 if (env.environment_variables != null) {
                     environmentVariables {
                         envs(env.environment_variables)
-                    }
-                }
-                // Build in docker
-                if (!cloud && build_in_docker) {
-                    buildInDocker {
-                        forcePull(is_dev_mode ? false : _get_bool(env.build_in_docker.force_pull, true))
-                        verbose(_get_bool(env.build_in_docker.verbose, false))
-                        // Enable docker in docker
-                        volume('/usr/bin/docker', '/usr/bin/docker')
-                        volume('/var/run/docker.sock', '/var/run/docker.sock')
-                        startCommand(env.build_in_docker.start_command)
-                        if (env.build_in_docker.image != null) {
-                            out.println("${env.full_name} building in docker image ${env.build_in_docker.image}")
-                            image(env.build_in_docker.image)
-                        } else if (env.build_in_docker.dockerfile != null) {
-                            out.println("${env.full_name} building in docker image from Dockerfile ${env.build_in_docker.dockerfile}")
-                            dockerfile('.', env.build_in_docker.dockerfile)
-                        }
                     }
                 }
             }

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -288,11 +288,11 @@ def add_job(env, is_dev_mode) {
                 }
             }
             publishers {
-                if (_slack_enabled(env) && "${SLACK_TOKEN}" != "") {
+                if (_slack_enabled(env)) {
                     out.println("${env.full_name} using Slack notification to: ${env.slack.room}")
                     slackNotifier {
                         teamDomain('SUNET')
-                        authToken("${SLACK_TOKEN}".toString())
+                        tokenCredentialId('SLACK_TOKEN')
                         room(env.slack.room)
                         notifyAborted(true)
                         notifyFailure(true)


### PR DESCRIPTION
This migrates our run-in-docker jobs and our docker image building jobs
to be run on the docker-plugin based cloud infrastructure.

This deprecates the usage of docker-custom-build-environment-plugin and
docker-build-publish-plugin.

To support that and the other progress towards our new ci infrastructure
there are also a couple of other minor commits.