### PR TITLE
Validate before use

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ slack:
   room: "devops"
   custom_message: ~
   sendas: ~
-# Jabber room to send updates to
-jabber: ~
 
 # Save artifacts from successful builds
 archive_artifacts:

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -543,12 +543,12 @@ for (org in orgs) {
             }
 
             repos.each {
-                if (ONLY_REPOS && !ONLY_REPOS.contains(it.name))
+                def name = it.name
+                def full_name = it.full_name.toLowerCase()
+                if (ONLY_REPOS && !ONLY_REPOS.contains(name))
                     return // return is like continue in a closure
-                out.println("repo: ${it.name}")
+                out.println("repo: ${name}")
                 try {
-                    def name = it.name
-                    def full_name = it.full_name.toLowerCase()
                     if (name != null && full_name != null && name != "null" && full_name != "null") {
                         env = load_env(it)
                         add_job(env, is_dev_mode)
@@ -563,7 +563,7 @@ for (org in orgs) {
                     }
                     out.println("---- EOJ ----")
                 } catch (RuntimeException ex) {
-                    out.println("---- Failed to process ${it.name} ----")
+                    out.println("---- Failed to process ${name} ----")
                     out.println(ex.toString());
                     out.println(ex.getMessage());
                     out.println("---- Trying next repo ----")

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -566,6 +566,7 @@ for (org in orgs) {
                     out.println("---- Failed to process ${name} ----")
                     out.println(ex.toString());
                     out.println(ex.getMessage());
+                    org.codehaus.groovy.runtime.StackTraceUtils.printSanitizedStackTrace(ex)
                     out.println("---- Trying next repo ----")
                     failure_in_repos = true
                 }

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -565,7 +565,6 @@ for (org in orgs) {
                 } catch (RuntimeException ex) {
                     out.println("---- Failed to process ${name} ----")
                     out.println(ex.toString());
-                    out.println(ex.getMessage());
                     org.codehaus.groovy.runtime.StackTraceUtils.printSanitizedStackTrace(ex)
                     out.println("---- Trying next repo ----")
                     failure_in_repos = true

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -93,6 +93,9 @@ def _get_int(value, default_value) {
 
 
 repo_must_be_signed = [:].withDefault{ false }
+repo_must_be_signed["SUNET/docker-jenkins"] = true
+repo_must_be_signed["SUNET/docker-jenkins-job"] = true
+repo_must_be_signed["SUNET/docker-registry-auth"] = true
 
 
 def load_env(repo) {

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -318,12 +318,6 @@ def add_job(env, is_dev_mode) {
                         sendAs(env.slack.sendas)
                     }
                 }
-                if (env.jabber != null) {
-                    out.println("${env.full_name} using Jabber notification to: ${env.jabber}")
-                    publishJabber(env.jabber) {
-                        strategyName('ANY_FAILURE')
-                    }
-                }
                 if (env.downstream != null && env.downstream.size() > 0) {
                     out.println("${env.full_name} using downstream ${env.downstream.join(', ')}")
                     downstream(env.downstream.join(', '))

--- a/github_docker_repos.groovy
+++ b/github_docker_repos.groovy
@@ -522,7 +522,7 @@ for (org in orgs) {
             // So you don't run into the request api request limit as quickly...
             //conn.addRequestProperty("Authorization", "token XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
 
-            repos = new JsonSlurper().parse(conn.getInputStream())
+            def repos = new JsonSlurper().parse(conn.getInputStream())
 
             // Terminate loop if we can't find a next link
             next_path = null


### PR DESCRIPTION
This does some minor cleanup, uses github-token to prevent rate-limiting,
and starts to validate some repos before using them.

First, we check the github verified flag, on the commit which master
points to, before reading and thus, trusting .jenkins.yaml.
This is a stop-gap measure before we can do full validation of the
repo before reading .jenkins.yaml.

After that we validate the actual tree before running anything from it.


This is a opt-in feature for now, and we only start using it on a couple
of repos which we know are signed, and only handled by folks which know
to sign them.